### PR TITLE
Update parsedown to 1.7.3

### DIFF
--- a/core/components/markdown/composer.json
+++ b/core/components/markdown/composer.json
@@ -1,6 +1,6 @@
 {
     "require": {
-        "erusev/parsedown": "1.6.0",
+        "erusev/parsedown": "1.7.3",
         "erusev/parsedown-extra": "0.7.1"
     }
 }


### PR DESCRIPTION
Hi @bezumkin,

I see you excluded the vendors folder from Git, but it's included in the package.. Do you add it when you build the package locally?

If so: could you run composer update there?