### PR TITLE
Remove possible BOM from start of string

### DIFF
--- a/core/components/markdown/elements/snippets/snippet.markdown.php
+++ b/core/components/markdown/elements/snippets/snippet.markdown.php
@@ -50,6 +50,10 @@ if (!empty($stripTags)) {
 // And decode entities
 $input = html_entity_decode($input, ENT_QUOTES, 'UTF-8');
 
+// Remove possible BOM from start of string
+$bom = pack('H*','EFBBBF');
+$input = str_replace($bom,'',$input);
+
 // Parse MODX tags
 if (empty($escapeTags)) {
     $input = $modx->newObject('modChunk')->process(null, $input);


### PR DESCRIPTION
When using a static Markdown file as input, there is a possibility that
it carries a BOM (byte order mark) character at the start of the string.

In HTML, this is inserted as special character: `&#65279;`

Don't ask me how it gets there.. It apparently indicates that you can
expect the file to be encoded as unicode, but in this case it breaks any
Markdown formatting on the first line, because the first character is
the BOM thingy. So headings for example, are not parsed on line 1.

For reference:

https://en.wikipedia.org/wiki/Byte_order_mark
https://stackoverflow.com/questions/2223882/whats-the-difference-between-utf-8-and-utf-8-without-bom